### PR TITLE
Restrict schedule creation/editing to admins and enforce authentication

### DIFF
--- a/BigBox_v4.Domain/User.cs
+++ b/BigBox_v4.Domain/User.cs
@@ -19,6 +19,7 @@ namespace BigBox_v4.Domain
         public string Email { get; set; } = string.Empty;
 
         [Required]
+        [Display(Name = "Password")]
         public string PasswordHash { get; set; } = string.Empty;
 
         public bool IsAdmin { get; set; } = false;

--- a/BigBox_v4/Controllers/AccountController.cs
+++ b/BigBox_v4/Controllers/AccountController.cs
@@ -24,9 +24,11 @@ namespace BigBox_v4.Controllers
             _passwordHasher = new PasswordHasher<User>();
         }
 
+        [AllowAnonymous]
         [HttpGet]
         public IActionResult Login() => View();
 
+        [AllowAnonymous]
         [HttpPost]
         public async Task<IActionResult> Login(string username, string password)
         {
@@ -79,9 +81,11 @@ namespace BigBox_v4.Controllers
             return RedirectToAction("Index", "Home");
         }
 
+        [AllowAnonymous]
         [HttpGet]
         public IActionResult Register() => View();
 
+        [AllowAnonymous]
         [HttpPost]
         public async Task<IActionResult> Register(User model)
         {

--- a/BigBox_v4/Controllers/DriverScheduleController.cs
+++ b/BigBox_v4/Controllers/DriverScheduleController.cs
@@ -48,6 +48,7 @@ namespace BigBox_v4.Controllers
         // GET: DriverSchedule/Create
         public async Task<IActionResult> Create(int? driverId)
         {
+            if (!UserIsAdmin()) return Forbid();
             await PopulateDriversDropdown();
 
             var schedule = new DriverSchedule
@@ -70,6 +71,7 @@ namespace BigBox_v4.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(DriverSchedule schedule)
         {
+            if (!UserIsAdmin()) return Forbid();
             if (ModelState.IsValid)
             {
                 try
@@ -96,6 +98,7 @@ namespace BigBox_v4.Controllers
         // GET: DriverSchedule/Edit/ID
         public async Task<IActionResult> Edit(int id)
         {
+            if (!UserIsAdmin()) return Forbid();
             var schedule = await _scheduleBusinessLogic.GetItemByIdAsync(id);
             if (schedule == null)
             {
@@ -111,6 +114,7 @@ namespace BigBox_v4.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, DriverSchedule schedule)
         {
+            if (!UserIsAdmin()) return Forbid();
             if (id != schedule.Id)
             {
                 return NotFound();
@@ -142,6 +146,7 @@ namespace BigBox_v4.Controllers
         // GET: DriverSchedule/Delete/ID
         public async Task<IActionResult> Delete(int id)
         {
+            if (!UserIsAdmin()) return Forbid();
             var schedule = await _scheduleBusinessLogic.GetItemByIdAsync(id);
             if (schedule == null)
             {
@@ -156,6 +161,7 @@ namespace BigBox_v4.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
+            if (!UserIsAdmin()) return Forbid();
             var schedule = await _scheduleBusinessLogic.GetItemByIdAsync(id);
             int driverId = schedule.DriverId;
 
@@ -173,6 +179,11 @@ namespace BigBox_v4.Controllers
         {
             var drivers = await _driversBusinessLogic.GetAllItemsAsync();
             ViewBag.Drivers = new SelectList(drivers, "Id", "Name");
+        }
+
+        private bool UserIsAdmin()
+        {
+            return User.HasClaim("IsAdmin", "True");
         }
     }
 }

--- a/BigBox_v4/Program.cs
+++ b/BigBox_v4/Program.cs
@@ -3,10 +3,18 @@ using BigBox_v4.Data;
 using BigBox_v4.Domain;
 using BigBox_v4.Middleware;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Authorization;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllersWithViews();
+builder.Services.AddControllersWithViews(options =>
+{
+    var policy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+    options.Filters.Add(new AuthorizeFilter(policy));
+});
 
 builder.Services.AddAuthentication("Cookies")
     .AddCookie("Cookies", options =>

--- a/BigBox_v4/Views/DriverSchedule/DriverTimetable.cshtml
+++ b/BigBox_v4/Views/DriverSchedule/DriverTimetable.cshtml
@@ -8,9 +8,12 @@
 
 <div class="container">
     <h1>Timetable for @driver.Name</h1>
-    <p>
-        <a asp-action="Create" asp-route-driverId="@driver.Id" asp-route-returnToDriver="true" class="btn btn-success">Add Schedule</a>
-    </p>
+    @if (User.HasClaim("IsAdmin", "True"))
+    {
+        <p>
+            <a asp-action="Create" asp-route-driverId="@driver.Id" asp-route-returnToDriver="true" class="btn btn-success">Add Schedule</a>
+        </p>
+    }
 
     <div class="row mb-3">
         <div class="col">
@@ -77,10 +80,13 @@
                                                 <td>@schedule.Status</td>
                                                 <td>@(string.IsNullOrEmpty(schedule.Notes) ? "N/A" : schedule.Notes)</td>
                                                 <td>
-                                                    <div class="btn-group" role="group">
-                                                        <a asp-action="Edit" asp-route-id="@schedule.Id" asp-route-returnToDriver="true" class="btn btn-primary btn-sm">Edit</a>
-                                                        <a asp-action="Delete" asp-route-id="@schedule.Id" asp-route-returnToDriver="true" class="btn btn-danger btn-sm">Delete</a>
-                                                    </div>
+                                                    @if (User.HasClaim("IsAdmin", "True"))
+                                                    {
+                                                        <div class="btn-group" role="group">
+                                                            <a asp-action="Edit" asp-route-id="@schedule.Id" asp-route-returnToDriver="true" class="btn btn-primary btn-sm">Edit</a>
+                                                            <a asp-action="Delete" asp-route-id="@schedule.Id" asp-route-returnToDriver="true" class="btn btn-danger btn-sm">Delete</a>
+                                                        </div>
+                                                    }
                                                 </td>
                                             </tr>
                                         }

--- a/BigBox_v4/Views/DriverSchedule/Index.cshtml
+++ b/BigBox_v4/Views/DriverSchedule/Index.cshtml
@@ -7,9 +7,12 @@
 
 <div class="container">
     <h1>Driver Schedules</h1>
-    <p>
-        <a asp-action="Create" class="btn btn-success">Create New Schedule</a>
-    </p>
+    @if (User.HasClaim("IsAdmin", "True"))
+    {
+        <p>
+            <a asp-action="Create" class="btn btn-success">Create New Schedule</a>
+        </p>
+    }
 
     @* https://localhost:7064/DriverSchedule/DriverTimetable/1 *@
 
@@ -59,10 +62,13 @@
                                                 <td>@schedule.Duration.ToString(@"hh\:mm")</td>
                                                 <td>@schedule.Status</td>
                                                 <td>
-                                                    <div class="btn-group" role="group">
-                                                        <a asp-action="Edit" asp-route-id="@schedule.Id" class="btn btn-primary btn-sm">Edit</a>
-                                                        <a asp-action="Delete" asp-route-id="@schedule.Id" class="btn btn-danger btn-sm">Delete</a>
-                                                    </div>
+                                                    @if (User.HasClaim("IsAdmin", "True"))
+                                                    {
+                                                        <div class="btn-group" role="group">
+                                                            <a asp-action="Edit" asp-route-id="@schedule.Id" class="btn btn-primary btn-sm">Edit</a>
+                                                            <a asp-action="Delete" asp-route-id="@schedule.Id" class="btn btn-danger btn-sm">Delete</a>
+                                                        </div>
+                                                    }
                                                 </td>
                                             </tr>
                                         }


### PR DESCRIPTION
This update enforces role-based access control and authentication across the application. Non-admin users can now only view schedules and are restricted from creating, editing, or deleting them. Additionally, users must be logged in to access any part of the main application, improving overall security.